### PR TITLE
Fix headers parsing

### DIFF
--- a/raml-mock-service.js
+++ b/raml-mock-service.js
@@ -101,7 +101,8 @@ function handler (method) {
 
   // Set up the default response headers.
   if (response.headers) {
-    response.headers.forEach(function (header) {
+    Object.keys(response.headers).forEach(function (kheader) {
+      var header = response.headers[kheader]
       if (header.default) {
         headers[header.name] = header.default
       } else if (header.example || header.examples) {


### PR DESCRIPTION
With raml like : 

```raml
/test:
  get:
    description: test

    responses:
        200:
          headers:
            Access-Control-Allow-Origin:
              example: "*"
          body:
            application/json:
...
```
current version of raml-mock-service fails with : 

```
TypeError: response.headers.forEach is not a function
    at handler (/usr/lib/node_modules/raml-mock-service/raml-mock-service.js:104:24)
    at /usr/lib/node_modules/raml-mock-service/node_modules/osprey-resources/osprey-resources.js:58:20
    at Array.forEach (native)
    at createResource (/usr/lib/node_modules/raml-mock-service/node_modules/osprey-resources/osprey-resources.js:57:13)
    at /usr/lib/node_modules/raml-mock-service/node_modules/osprey-resources/osprey-resources.js:33:7
    at Array.forEach (native)
    at createResources (/usr/lib/node_modules/raml-mock-service/node_modules/osprey-resources/osprey-resources.js:32:15)
    at ospreyResources (/usr/lib/node_modules/raml-mock-service/node_modules/osprey-resources/osprey-resources.js:17:10)
    at ospreyMockServer (/usr/lib/node_modules/raml-mock-service/raml-mock-service.js:20:10)
    at createServer (/usr/lib/node_modules/raml-mock-service/raml-mock-service.js:34:11)
```

This is because response.headers is a hash, not an Array. 
This commit fix this by iterating correctly through the hash.
